### PR TITLE
Restore .gitignore to original state.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+assets/components
+assets/javascript/vendor/motion-ui
+assets/javascript/vendor/what-input

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
-assets/components
-assets/javascript/vendor/motion-ui
-assets/javascript/vendor/what-input
+.DS_Store
+*.sass-cache*
+*.log
+node_modules/
+assets/stylesheets/
+assets/components/
+assets/javascript/vendor/
+assets/javascript/foundation.js
+assets/javascript/custom/demosite.js
+packaged/
+wpcs/


### PR DESCRIPTION
We lost some of the original WP FoundationPress ignored files (generated bower/gulp stuff, etc.), should be back in business now.
